### PR TITLE
Lore change not applying when shift clicking item

### DIFF
--- a/bukkit/src/main/java/dev/jsinco/brewery/bukkit/listeners/InventoryEventListener.java
+++ b/bukkit/src/main/java/dev/jsinco/brewery/bukkit/listeners/InventoryEventListener.java
@@ -58,13 +58,11 @@ public class InventoryEventListener implements Listener {
 
         ItemStack hoveredItem = event.getCurrentItem();
         Stream<ItemStack> relatedItems;
-        if (upperInventoryIsClicked) {
-            if (hoveredItem != null) {
-                BrewAdapter.fromItem(hoveredItem)
-                        .map(brew -> BrewAdapter.toItem(brew, new BrewImpl.State.Other()))
-                        .map(ItemStack::getItemMeta)
-                        .ifPresent(hoveredItem::setItemMeta);
-            }
+        if (upperInventoryIsClicked && hoveredItem != null) {
+            BrewAdapter.fromItem(hoveredItem)
+                    .map(brew -> BrewAdapter.toItem(brew, new BrewImpl.State.Other()))
+                    .map(ItemStack::getItemMeta)
+                    .ifPresent(hoveredItem::setItemMeta);
         }
         if (action == InventoryAction.MOVE_TO_OTHER_INVENTORY) {
             // player takes something out

--- a/bukkit/src/main/java/dev/jsinco/brewery/bukkit/listeners/InventoryEventListener.java
+++ b/bukkit/src/main/java/dev/jsinco/brewery/bukkit/listeners/InventoryEventListener.java
@@ -59,12 +59,11 @@ public class InventoryEventListener implements Listener {
         ItemStack hoveredItem = event.getCurrentItem();
         Stream<ItemStack> relatedItems;
         if (upperInventoryIsClicked) {
-            int slot = event.getRawSlot();
-            ItemStack initial = view.getItem(slot);
-            if (initial != null) {
-                view.setItem(slot, BrewAdapter.fromItem(initial)
+            if (hoveredItem != null) {
+                BrewAdapter.fromItem(hoveredItem)
                         .map(brew -> BrewAdapter.toItem(brew, new BrewImpl.State.Other()))
-                        .orElse(initial));
+                        .map(ItemStack::getItemMeta)
+                        .ifPresent(hoveredItem::setItemMeta);
             }
         }
         if (action == InventoryAction.MOVE_TO_OTHER_INVENTORY) {


### PR DESCRIPTION
The lore of the item is meant to change after it has been transferred to the player inventory for both distilleries and barrels. There's 3 different types of lore; informative, normal, sealed. When a brew is in a barrel/distillery it should show the informative lore, when it is in an player inventory it should show the normal lore