### PR TITLE
Add sound and particle effects for cauldron

### DIFF
--- a/bukkit/src/main/java/dev/jsinco/brewery/bukkit/breweries/BukkitCauldron.java
+++ b/bukkit/src/main/java/dev/jsinco/brewery/bukkit/breweries/BukkitCauldron.java
@@ -1,6 +1,5 @@
 package dev.jsinco.brewery.bukkit.breweries;
 
-import com.destroystokyo.paper.ParticleBuilder;
 import dev.jsinco.brewery.brew.Brew;
 import dev.jsinco.brewery.brew.BrewImpl;
 import dev.jsinco.brewery.brew.BrewingStep;

--- a/bukkit/src/main/java/dev/jsinco/brewery/bukkit/listeners/PlayerEventListener.java
+++ b/bukkit/src/main/java/dev/jsinco/brewery/bukkit/listeners/PlayerEventListener.java
@@ -185,8 +185,9 @@ public class PlayerEventListener implements Listener {
         boolean addedIngredient = cauldron.addIngredient(itemStack, player);
         if (addedIngredient) {
             updateHeldItem(decreaseItem(itemStack, player), player, hand);
+            String soundKey = itemStack.getType() == Material.POTION ? "minecraft:item.bottle.empty" : "minecraft:item.bundle.insert";
             block.getWorld().playSound(
-                    Sound.sound().source(Sound.Source.BLOCK).type(Key.key("minecraft:item.bottle.empty")).build()
+                    Sound.sound().source(Sound.Source.BLOCK).type(Key.key(soundKey)).build()
                     , block.getX() + 0.5, block.getY() + 1, block.getZ() + 0.5
             );
             try {

--- a/bukkit/src/main/java/dev/jsinco/brewery/bukkit/listeners/PlayerEventListener.java
+++ b/bukkit/src/main/java/dev/jsinco/brewery/bukkit/listeners/PlayerEventListener.java
@@ -159,10 +159,6 @@ public class PlayerEventListener implements Listener {
                         if (BukkitCauldron.decrementLevel(block)) {
                             ListenerUtil.removeActiveSinglePositionStructure(cauldronOptional.get(), breweryRegistry, database);
                         }
-                        block.getWorld().playSound(
-                                Sound.sound().source(Sound.Source.BLOCK).type(Key.key("minecraft:item.bottle.fill")).build(),
-                                block.getX() + 0.5, block.getY() + 1, block.getZ() + 0.5
-                        );
                     });
         }
         cauldronOptional
@@ -185,11 +181,6 @@ public class PlayerEventListener implements Listener {
         boolean addedIngredient = cauldron.addIngredient(itemStack, player);
         if (addedIngredient) {
             updateHeldItem(decreaseItem(itemStack, player), player, hand);
-            String soundKey = itemStack.getType() == Material.POTION ? "minecraft:item.bottle.empty" : "minecraft:item.bundle.insert";
-            block.getWorld().playSound(
-                    Sound.sound().source(Sound.Source.BLOCK).type(Key.key(soundKey)).build()
-                    , block.getX() + 0.5, block.getY() + 1, block.getZ() + 0.5
-            );
             try {
                 database.updateValue(BukkitCauldronDataType.INSTANCE, cauldron);
             } catch (PersistenceException e) {

--- a/bukkit/src/main/java/dev/jsinco/brewery/bukkit/listeners/PlayerEventListener.java
+++ b/bukkit/src/main/java/dev/jsinco/brewery/bukkit/listeners/PlayerEventListener.java
@@ -24,8 +24,6 @@ import dev.jsinco.brewery.effect.text.DrunkTextRegistry;
 import dev.jsinco.brewery.effect.text.DrunkTextTransformer;
 import dev.jsinco.brewery.recipes.RecipeRegistryImpl;
 import dev.jsinco.brewery.structure.PlacedStructureRegistryImpl;
-import net.kyori.adventure.key.Key;
-import net.kyori.adventure.sound.Sound;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import org.bukkit.GameMode;
 import org.bukkit.Material;

--- a/bukkit/src/main/java/dev/jsinco/brewery/bukkit/listeners/PlayerEventListener.java
+++ b/bukkit/src/main/java/dev/jsinco/brewery/bukkit/listeners/PlayerEventListener.java
@@ -24,6 +24,8 @@ import dev.jsinco.brewery.effect.text.DrunkTextRegistry;
 import dev.jsinco.brewery.effect.text.DrunkTextTransformer;
 import dev.jsinco.brewery.recipes.RecipeRegistryImpl;
 import dev.jsinco.brewery.structure.PlacedStructureRegistryImpl;
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.sound.Sound;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import org.bukkit.GameMode;
 import org.bukkit.Material;
@@ -157,6 +159,10 @@ public class PlayerEventListener implements Listener {
                         if (BukkitCauldron.decrementLevel(block)) {
                             ListenerUtil.removeActiveSinglePositionStructure(cauldronOptional.get(), breweryRegistry, database);
                         }
+                        block.getWorld().playSound(
+                                Sound.sound().source(Sound.Source.BLOCK).type(Key.key("minecraft:item.bottle.fill")).build(),
+                                block.getX() + 0.5, block.getY() + 1, block.getZ() + 0.5
+                        );
                     });
         }
         cauldronOptional
@@ -179,6 +185,10 @@ public class PlayerEventListener implements Listener {
         boolean addedIngredient = cauldron.addIngredient(itemStack, player);
         if (addedIngredient) {
             updateHeldItem(decreaseItem(itemStack, player), player, hand);
+            block.getWorld().playSound(
+                    Sound.sound().source(Sound.Source.BLOCK).type(Key.key("minecraft:item.bottle.empty")).build()
+                    , block.getX() + 0.5, block.getY() + 1, block.getZ() + 0.5
+            );
             try {
                 database.updateValue(BukkitCauldronDataType.INSTANCE, cauldron);
             } catch (PersistenceException e) {


### PR DESCRIPTION
On insert potion item: `minecraft:item.bottle.empty`
On insert other item: `minecraft:item.bundle.insert`
On retrieve brew: `minecraft:item.bottle.fill`

There's thousands of sounds you can choose between here though. There might be better alternatives, at least for `item.bundle.insert`