### PR TITLE
Add support for item models

### DIFF
--- a/bukkit/src/main/java/dev/jsinco/brewery/bukkit/recipe/BukkitRecipeResult.java
+++ b/bukkit/src/main/java/dev/jsinco/brewery/bukkit/recipe/BukkitRecipeResult.java
@@ -212,7 +212,7 @@ public class BukkitRecipeResult implements RecipeResult<ItemStack> {
             return this;
         }
 
-        public Builder itemModel(String itemModel) {
+        public Builder itemModel(@Nullable String itemModel) {
             if (itemModel != null) {
                 this.itemModel = BreweryKey.parse(itemModel);
             }

--- a/bukkit/src/main/java/dev/jsinco/brewery/bukkit/recipe/BukkitRecipeResultReader.java
+++ b/bukkit/src/main/java/dev/jsinco/brewery/bukkit/recipe/BukkitRecipeResultReader.java
@@ -22,6 +22,7 @@ public class BukkitRecipeResultReader implements RecipeResultReader<ItemStack> {
         return new BukkitRecipeResult.Builder()
                 .recipeEffects(getRecipeEffects(configurationSection))
                 .customModelData(configurationSection.getInt("potion-attributes.custom-model-data", -1))
+                .itemModel(configurationSection.getString("potion-attributes.item-model", null))
                 .lore(QualityData.readQualityFactoredStringList(configurationSection.getStringList("potion-attributes.lore")))
                 .glint(configurationSection.getBoolean("potion-attributes.glint", false))
                 .names(QualityData.readQualityFactoredString(configurationSection.getString("potion-attributes.name")))


### PR DESCRIPTION
Just adds support for papers custom item models. Syntax in configs would be `NameSpace:Key` (e.g. `minecraft:dirt`).

Since we're using modern paper, maybe we should just jump head-first into their `DataComponent`s  interface instead of using `ItemMeta`?