### PR TITLE
Tweak recipe difficulty

### DIFF
--- a/api/src/main/java/dev/jsinco/brewery/brew/BrewingStep.java
+++ b/api/src/main/java/dev/jsinco/brewery/brew/BrewingStep.java
@@ -25,8 +25,8 @@ public sealed interface BrewingStep {
     StepType stepType();
 
     private static double nearbyValueScore(long expected, long value) {
-        double maxValue = Math.max(expected, value);
-        return 1 - Math.abs(expected - value) / maxValue;
+        double diff = Math.abs(expected - value);
+        return 1 - Math.max(diff / expected, 0D);
     }
 
     private static double getIngredientsScore(Map<Ingredient, Integer> target, Map<Ingredient, Integer> actual) {

--- a/api/src/main/java/dev/jsinco/brewery/brew/BrewingStep.java
+++ b/api/src/main/java/dev/jsinco/brewery/brew/BrewingStep.java
@@ -90,7 +90,7 @@ public sealed interface BrewingStep {
                 return 0D;
             }
             double cauldronTypeScore = cauldronType.equals(otherType) ? 1D : 0D;
-            return cauldronTypeScore * BrewingStep.nearbyValueScore(this.brewTime.moment(), otherTime.moment()) * BrewingStep.getIngredientsScore((Map<Ingredient, Integer>) this.ingredients, (Map<Ingredient, Integer>) otherIngredients);
+            return cauldronTypeScore * Math.sqrt(BrewingStep.nearbyValueScore(this.brewTime.moment(), otherTime.moment())) * BrewingStep.getIngredientsScore((Map<Ingredient, Integer>) this.ingredients, (Map<Ingredient, Integer>) otherIngredients);
         }
 
         @Override
@@ -119,7 +119,7 @@ public sealed interface BrewingStep {
             if (!(other instanceof Distill(int otherRuns))) {
                 return 0D;
             }
-            return BrewingStep.nearbyValueScore(this.runs, otherRuns);
+            return Math.sqrt(BrewingStep.nearbyValueScore(this.runs, otherRuns));
         }
 
         @Override
@@ -148,7 +148,7 @@ public sealed interface BrewingStep {
                 return 0D;
             }
             double barrelTypeScore = barrelType.equals(BarrelType.ANY) || barrelType.equals(otherType) ? 1D : 0.9D;
-            return barrelTypeScore * BrewingStep.nearbyValueScore(this.age.moment(), otherAge.moment());
+            return barrelTypeScore * Math.sqrt(BrewingStep.nearbyValueScore(this.age.moment(), otherAge.moment()));
         }
 
         @Override
@@ -189,7 +189,7 @@ public sealed interface BrewingStep {
                 return 0D;
             }
             double mixTimeScore = time1.moment() < this.time.moment() ? 1D : BrewingStep.nearbyValueScore(this.time.moment(), time1.moment());
-            return BrewingStep.getIngredientsScore((Map<Ingredient, Integer>) this.ingredients, (Map<Ingredient, Integer>) ingredients1) * mixTimeScore;
+            return BrewingStep.getIngredientsScore((Map<Ingredient, Integer>) this.ingredients, (Map<Ingredient, Integer>) ingredients1) * Math.sqrt(mixTimeScore);
         }
 
         public Mix withTime(Moment time) {

--- a/api/src/main/java/dev/jsinco/brewery/recipe/Recipe.java
+++ b/api/src/main/java/dev/jsinco/brewery/recipe/Recipe.java
@@ -8,7 +8,7 @@ public interface Recipe<I> {
 
     String getRecipeName();
 
-    int getBrewDifficulty();
+    double getBrewDifficulty();
 
     List<BrewingStep> getSteps();
 

--- a/bukkit/src/test/java/dev/jsinco/brewery/bukkit/brews/BrewTest.java
+++ b/bukkit/src/test/java/dev/jsinco/brewery/bukkit/brews/BrewTest.java
@@ -256,7 +256,7 @@ class BrewTest {
                 )
                 .build();
         boolean hasHadNullQuality = false;
-        for (int i = 3; i < 20; i++) {
+        for (int i = 3; i < 10; i++) {
             BrewImpl brew = new BrewImpl(
                     List.of(
                             new BrewingStep.Cook(

--- a/core/src/main/java/dev/jsinco/brewery/recipes/BrewScoreImpl.java
+++ b/core/src/main/java/dev/jsinco/brewery/recipes/BrewScoreImpl.java
@@ -46,6 +46,7 @@ public class BrewScoreImpl implements BrewScore {
     }
 
     private double applyDifficulty(double score) {
+        score = Math.min(score + 0.05, 1D);
         // Avoid extreme point, log(0) is minus infinity
         if (brewDifficulty <= 0) {
             return 1D;
@@ -55,9 +56,9 @@ public class BrewScoreImpl implements BrewScore {
         if (brewDifficulty == 1) {
             scoreWithDifficulty = score;
         } else {
-            scoreWithDifficulty = (Math.exp(score * Math.log(brewDifficulty)) - 1) / (brewDifficulty - 1);
+            scoreWithDifficulty = (Math.pow(brewDifficulty, 3 * score) - 1) / (Math.pow(brewDifficulty, 3) - 1);
         }
-        return Math.max(Math.min(scoreWithDifficulty + 0.05, 1D) - 0.3, 0.0) * 1 / 0.7;
+        return Math.max(scoreWithDifficulty - 0.3, 0.0) * 1 / 0.7;
     }
 
     public String displayName() {

--- a/core/src/main/java/dev/jsinco/brewery/recipes/BrewScoreImpl.java
+++ b/core/src/main/java/dev/jsinco/brewery/recipes/BrewScoreImpl.java
@@ -31,10 +31,10 @@ public class BrewScoreImpl implements BrewScore {
         this.brewDifficulty = 1;
     }
 
-    public BrewScoreImpl(List<Double> scores, boolean completed, int brewDifficulty) {
+    public BrewScoreImpl(List<Double> scores, boolean completed, double brewDifficulty) {
         this.scores = scores;
         this.completed = completed;
-        this.brewDifficulty = (double) brewDifficulty / 2;
+        this.brewDifficulty = brewDifficulty / 2;
     }
 
     public double getPartialScore(int stepIndex) {

--- a/core/src/main/java/dev/jsinco/brewery/recipes/RecipeImpl.java
+++ b/core/src/main/java/dev/jsinco/brewery/recipes/RecipeImpl.java
@@ -15,7 +15,7 @@ public class RecipeImpl<I> implements Recipe<I> {
     @Getter
     private final String recipeName;
     @Getter
-    private final int brewDifficulty;
+    private final double brewDifficulty;
     @NotNull
     private final List<BrewingStep> steps;
 
@@ -24,7 +24,7 @@ public class RecipeImpl<I> implements Recipe<I> {
     private final RecipeResult<I> recipeResult;
 
 
-    private RecipeImpl(String recipeName, int brewDifficulty, List<BrewingStep> steps,
+    private RecipeImpl(String recipeName, double brewDifficulty, List<BrewingStep> steps,
                        @NotNull RecipeResult<I> recipeResult) {
         this.recipeName = recipeName;
         this.brewDifficulty = brewDifficulty;
@@ -34,7 +34,7 @@ public class RecipeImpl<I> implements Recipe<I> {
 
     public static class Builder<I> {
         private final String recipeName;
-        private int brewDifficulty = 1;
+        private double brewDifficulty = 1;
         private RecipeResult<I> recipeResult;
         private List<BrewingStep> steps;
 
@@ -42,7 +42,7 @@ public class RecipeImpl<I> implements Recipe<I> {
             this.recipeName = recipeName;
         }
 
-        public Builder<I> brewDifficulty(int brewDifficulty) {
+        public Builder<I> brewDifficulty(double brewDifficulty) {
             this.brewDifficulty = brewDifficulty;
             return this;
         }

--- a/core/src/main/java/dev/jsinco/brewery/recipes/RecipeReader.java
+++ b/core/src/main/java/dev/jsinco/brewery/recipes/RecipeReader.java
@@ -63,7 +63,7 @@ public class RecipeReader<I> {
      */
     private RecipeImpl<I> getRecipe(ConfigurationSection recipe, String recipeName) {
         return new RecipeImpl.Builder<I>(recipeName)
-                .brewDifficulty(recipe.getInt("brew-difficulty", 1))
+                .brewDifficulty(recipe.getDouble("brew-difficulty", 1D))
                 .recipeResult(recipeResultReader.readRecipeResult(recipe))
                 .steps(parseSteps(recipe.getMapList("steps")))
                 .build();


### PR DESCRIPTION
Made the difficulty function more sensitive to difficulties within the range [0,10], see this following equation and use a visualizer such as geogebra for it:
![bild](https://github.com/user-attachments/assets/02a8cd40-8caa-427d-8868-62e9c0e0aebf)
(d is the difficulty value)

I also made the dependence on time/distill runs less sensitive. Please test this if it feels alright
