### PR TITLE
Enforce SQL foreign key constraints

### DIFF
--- a/core/src/main/resources/database/migration/foreign_keys_on_migration.sql
+++ b/core/src/main/resources/database/migration/foreign_keys_on_migration.sql
@@ -1,0 +1,10 @@
+PRAGMA foreign_keys = OFF;
+
+DELETE
+FROM barrel_brews
+WHERE (unique_x, unique_y, unique_z, world_uuid) NOT IN (SELECT unique_x, unique_y, unique_z, world_uuid FROM barrels);
+
+DELETE
+FROM distillery_brews
+WHERE (unique_x, unique_y, unique_z, world_uuid) NOT IN (SELECT unique_x, unique_y, unique_z, world_uuid FROM distilleries);
+PRAGMA foreign_keys = ON;

--- a/core/src/main/resources/database/sqlite/create_all_tables.sql
+++ b/core/src/main/resources/database/sqlite/create_all_tables.sql
@@ -1,3 +1,5 @@
+PRAGMA foreign_keys = OFF;
+
 CREATE TABLE IF NOT EXISTS barrels
 (
     origin_x       INTEGER,
@@ -99,3 +101,5 @@ CREATE TABLE IF NOT EXISTS mixers
     brew       JSON,
     PRIMARY KEY (cauldron_x, cauldron_y, cauldron_z, world_uuid)
 );
+
+PRAGMA foreign_keys = ON;

--- a/core/src/main/resources/database/sqlite/create_all_tables.sql
+++ b/core/src/main/resources/database/sqlite/create_all_tables.sql
@@ -1,5 +1,3 @@
-PRAGMA foreign_keys = OFF;
-
 CREATE TABLE IF NOT EXISTS barrels
 (
     origin_x       INTEGER,
@@ -101,5 +99,3 @@ CREATE TABLE IF NOT EXISTS mixers
     brew       JSON,
     PRIMARY KEY (cauldron_x, cauldron_y, cauldron_z, world_uuid)
 );
-
-PRAGMA foreign_keys = ON;


### PR DESCRIPTION
I just noticed that deleting either a distillery or a barrel will not remove the brews in the database. I added a `ON DELETE CASCADE` statement, but by default for sqlite, this is not enforced. This pr does the following:
- Enforce foreign keys // if something gets deleted in the parent table, its remaining data in the child table will also be deleted
- Add a database migration that removes existing brews without any linked structure