### PR TITLE
Make unique position unique

### DIFF
--- a/bukkit/src/main/java/dev/jsinco/brewery/bukkit/listeners/BlockEventListener.java
+++ b/bukkit/src/main/java/dev/jsinco/brewery/bukkit/listeners/BlockEventListener.java
@@ -75,7 +75,7 @@ public class BlockEventListener implements Listener {
             return;
         }
         event.getPlayer().sendMessage(MiniMessage.miniMessage().deserialize(TranslationsConfig.BARREL_CREATE));
-        BukkitBarrel barrel = new BukkitBarrel(event.getBlock().getLocation(), placedBreweryStructure, placedBreweryStructure.getStructure().getMeta(StructureMeta.INVENTORY_SIZE), placedStructurePair.second());
+        BukkitBarrel barrel = new BukkitBarrel(BukkitAdapter.toLocation(placedBreweryStructure.getUnique()), placedBreweryStructure, placedBreweryStructure.getStructure().getMeta(StructureMeta.INVENTORY_SIZE), placedStructurePair.second());
         placedBreweryStructure.setHolder(barrel);
         placedStructureRegistry.registerStructure(placedBreweryStructure);
         breweryRegistry.registerInventory(barrel);


### PR DESCRIPTION
The unique position is used internally as a sql primary key, this means no other barrel should have an overlapping unique position.

The previous problem with this is that the unique position used for the barrel was the position of the sign, but this block is no longer part of the barrel, which means another barrel could technically share this position. If this ever happend, it would cause SQL primary key constraint issues.