### PR TITLE
Change drunkenwalk directions more often

### DIFF
--- a/bukkit/src/main/java/dev/jsinco/brewery/bukkit/effect/event/DrunkenWalkHandler.java
+++ b/bukkit/src/main/java/dev/jsinco/brewery/bukkit/effect/event/DrunkenWalkHandler.java
@@ -20,7 +20,7 @@ class DrunkenWalkHandler {
     private final Player player;
     private Vector currentPush;
 
-    private static int DIRECTION_INTERVAL = 40;
+    private static int DIRECTION_INTERVAL = 20;
     private static double MINIMUM_PUSH_MAGNITUDE = 0.1;
     private static double MAXIMUM_PUSH_MAGNITUDE = 0.4;
     private static final Random RANDOM = new Random();


### PR DESCRIPTION
Previous interval between direction change was too long, I think this might be a bit better. (Going from a changing directions in 2 seconds to 1 seconds)