### PR TITLE
Fix coloration of cauldron particles + lava issue fix

### DIFF
--- a/bukkit/src/main/java/dev/jsinco/brewery/bukkit/recipe/BukkitRecipeResultReader.java
+++ b/bukkit/src/main/java/dev/jsinco/brewery/bukkit/recipe/BukkitRecipeResultReader.java
@@ -42,7 +42,7 @@ public class BukkitRecipeResultReader implements RecipeResultReader<ItemStack> {
                         .lore(lore.getOrDefault(brewQuality, List.of()))
                         .glint(glint.getOrDefault(brewQuality, false))
                         .color(Preconditions.checkNotNull(colors.get(brewQuality)))
-                        .appendBrewInfoLore(appendBrewInfoLore.getOrDefault(brewQuality, false))
+                        .appendBrewInfoLore(appendBrewInfoLore.getOrDefault(brewQuality, true))
                         .customId(customId.get(brewQuality))
                         .customModelData(customModelData.getOrDefault(brewQuality, -1))
                         .itemModel(itemModel.get(brewQuality))


### PR DESCRIPTION
Particle colors depends on more stuff now:
- What the initial liquid in the cauldron is
- The exact coloration of the resulting brew (better than before)

Also fixes lava not decreasing in level once one brew is extracted, and also now plays the sound effect for extraction again