### PR TITLE
Avoid the onLoad method

### DIFF
--- a/bukkit/src/main/java/dev/jsinco/brewery/bukkit/TheBrewingProject.java
+++ b/bukkit/src/main/java/dev/jsinco/brewery/bukkit/TheBrewingProject.java
@@ -99,8 +99,7 @@ public class TheBrewingProject extends JavaPlugin implements TheBrewingProjectAp
     @Getter
     private PlayerWalkListener playerWalkListener;
 
-    @Override
-    public void onLoad() {
+    public void initialize() {
         instance = this;
         Config.load(this.getDataFolder(), serializers());
         TranslationsConfig.reload(this.getDataFolder());
@@ -189,6 +188,7 @@ public class TheBrewingProject extends JavaPlugin implements TheBrewingProjectAp
 
     @Override
     public void onEnable() {
+        initialize();
         integrationManager.init();
         saveResources();
         this.database = new Database(DatabaseDriver.SQLITE);


### PR DESCRIPTION
If the plugin fails on load, then it will still continue to onEnable (this is a behavior in paper), let's just avoid that