### PR TITLE
Avoid updating inventories as much

### DIFF
--- a/api/src/main/java/dev/jsinco/brewery/breweries/InventoryAccessible.java
+++ b/api/src/main/java/dev/jsinco/brewery/breweries/InventoryAccessible.java
@@ -11,6 +11,8 @@ public interface InventoryAccessible<IS, I> {
 
     boolean open(@NotNull BreweryLocation breweryLocation, @NotNull UUID playerUuid);
 
+    void close(boolean silent);
+
     boolean inventoryAllows(@NotNull UUID playerUuid, @NotNull IS item);
 
     boolean inventoryAllows(@NotNull IS item);

--- a/bukkit/src/main/java/dev/jsinco/brewery/bukkit/TheBrewingProject.java
+++ b/bukkit/src/main/java/dev/jsinco/brewery/bukkit/TheBrewingProject.java
@@ -241,6 +241,12 @@ public class TheBrewingProject extends JavaPlugin implements TheBrewingProjectAp
     @Override
     public void onDisable() {
         try {
+            breweryRegistry.<BukkitBarrel>getOpened(StructureType.BARREL).forEach(barrel -> barrel.close(true));
+            breweryRegistry.<BukkitDistillery>getOpened(StructureType.DISTILLERY).forEach(distillery -> distillery.close(true));
+        } catch (Throwable e) {
+            Logger.logErr(e);
+        }
+        try {
             database.setSingleton(BreweryTimeDataType.INSTANCE, time).join();
             database.flush().join();
         } catch (PersistenceException e) {

--- a/bukkit/src/main/java/dev/jsinco/brewery/bukkit/breweries/barrel/BukkitBarrel.java
+++ b/bukkit/src/main/java/dev/jsinco/brewery/bukkit/breweries/barrel/BukkitBarrel.java
@@ -29,13 +29,7 @@ import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 
 @Getter
 public class BukkitBarrel implements Barrel<BukkitBarrel, ItemStack, Inventory> {

--- a/bukkit/src/main/java/dev/jsinco/brewery/bukkit/breweries/distillery/BukkitDistillery.java
+++ b/bukkit/src/main/java/dev/jsinco/brewery/bukkit/breweries/distillery/BukkitDistillery.java
@@ -191,8 +191,7 @@ public class BukkitDistillery implements Distillery<BukkitDistillery, ItemStack,
     public void tickInventory() {
         checkDirty();
         if (inventoryUnpopulated()) {
-            mixture.getInventory().clear();
-            distillate.getInventory().clear();
+            close(false);
             TheBrewingProject.getInstance().getBreweryRegistry().unregisterOpened(this);
             // Distilling results can be computed later on
             return;
@@ -200,15 +199,15 @@ public class BukkitDistillery implements Distillery<BukkitDistillery, ItemStack,
         if (!mixture.getInventory().getViewers().isEmpty() || !distillate.getInventory().getViewers().isEmpty()) {
             this.recentlyAccessed = TheBrewingProject.getInstance().getTime();
         }
-        boolean hasChanged = mixture.updateBrewsFromInventory();
-        distillate.updateBrewsFromInventory();
-        if (hasChanged) {
-            resetStartTime();
-        }
         long diff = getTimeProcessed();
         long processTime = getProcessTime();
         if (diff < processTime || mixture.isEmpty()) {
             return;
+        }
+        boolean hasChanged = mixture.updateBrewsFromInventory();
+        distillate.updateBrewsFromInventory();
+        if (hasChanged) {
+            resetStartTime();
         }
         transferItems(mixture, distillate, (int) (getStructure().getStructure().getMeta(StructureMeta.PROCESS_AMOUNT) * (diff / processTime)));
         distillate.updateInventoryFromBrews();

--- a/bukkit/src/main/java/dev/jsinco/brewery/bukkit/breweries/distillery/BukkitDistillery.java
+++ b/bukkit/src/main/java/dev/jsinco/brewery/bukkit/breweries/distillery/BukkitDistillery.java
@@ -22,11 +22,7 @@ import dev.jsinco.brewery.vector.BreweryLocation;
 import lombok.Getter;
 import net.kyori.adventure.sound.Sound;
 import net.kyori.adventure.text.minimessage.MiniMessage;
-import org.bukkit.Bukkit;
-import org.bukkit.Color;
-import org.bukkit.Location;
-import org.bukkit.Material;
-import org.bukkit.Particle;
+import org.bukkit.*;
 import org.bukkit.block.Block;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.entity.Player;
@@ -34,14 +30,8 @@ import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Locale;
-import java.util.Optional;
-import java.util.Queue;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
+import java.util.stream.Stream;
 
 public class BukkitDistillery implements Distillery<BukkitDistillery, ItemStack, Inventory> {
 
@@ -83,6 +73,15 @@ public class BukkitDistillery implements Distillery<BukkitDistillery, ItemStack,
             return openInventory(distillate, player);
         }
         return false;
+    }
+
+    @Override
+    public void close(boolean silent) {
+        Stream.of(mixture, distillate).forEach(inventory -> {
+                    inventory.updateBrewsFromInventory();
+                    inventory.getInventory().clear();
+                }
+        );
     }
 
     private void playInteractionEffects(BreweryLocation location, Player player) {

--- a/bukkit/src/main/java/dev/jsinco/brewery/bukkit/breweries/distillery/BukkitDistillery.java
+++ b/bukkit/src/main/java/dev/jsinco/brewery/bukkit/breweries/distillery/BukkitDistillery.java
@@ -199,17 +199,22 @@ public class BukkitDistillery implements Distillery<BukkitDistillery, ItemStack,
         if (!mixture.getInventory().getViewers().isEmpty() || !distillate.getInventory().getViewers().isEmpty()) {
             this.recentlyAccessed = TheBrewingProject.getInstance().getTime();
         }
-        long diff = getTimeProcessed();
+        long timeProcessed = getTimeProcessed();
         long processTime = getProcessTime();
-        if (diff < processTime || mixture.isEmpty()) {
+        // Process has changed one extra tick, to avoid running a sound if the mixture inventory changed
+        if (timeProcessed < processTime - 1 || mixture.getInventory().isEmpty()) {
             return;
         }
         boolean hasChanged = mixture.updateBrewsFromInventory();
         distillate.updateBrewsFromInventory();
         if (hasChanged) {
             resetStartTime();
+            return;
         }
-        transferItems(mixture, distillate, (int) (getStructure().getStructure().getMeta(StructureMeta.PROCESS_AMOUNT) * (diff / processTime)));
+        if (timeProcessed < processTime) {
+            return;
+        }
+        transferItems(mixture, distillate, (int) (getStructure().getStructure().getMeta(StructureMeta.PROCESS_AMOUNT) * (timeProcessed / processTime)));
         distillate.updateInventoryFromBrews();
         mixture.updateInventoryFromBrews();
         resetStartTime();


### PR DESCRIPTION
Most notably decreases inventory update frequency in barrels by about 2000 times. And distillery inventory stuff is really only going to process once the distillery process takes effect.