### PR TITLE
added Brewing Time Options (Hover and Actionbar), toggle chat message

### DIFF
--- a/bukkit/src/main/java/dev/jsinco/brewery/bukkit/TheBrewingProject.java
+++ b/bukkit/src/main/java/dev/jsinco/brewery/bukkit/TheBrewingProject.java
@@ -30,6 +30,7 @@ import dev.jsinco.brewery.bukkit.effect.event.DrunkEventExecutor;
 import dev.jsinco.brewery.bukkit.event.*;
 import dev.jsinco.brewery.bukkit.ingredient.BukkitIngredientManager;
 import dev.jsinco.brewery.bukkit.integration.IntegrationManagerImpl;
+import dev.jsinco.brewery.bukkit.task.CauldronHoverTask;
 import dev.jsinco.brewery.bukkit.migration.Migrations;
 import dev.jsinco.brewery.bukkit.recipe.BukkitRecipeResultReader;
 import dev.jsinco.brewery.bukkit.recipe.DefaultRecipeReader;
@@ -111,6 +112,7 @@ public class TheBrewingProject extends JavaPlugin implements TheBrewingProjectAp
     private PlayerWalkListener playerWalkListener;
     @Getter
     private ModifierManager modifierManager = new ModifierManagerImpl();
+    private CauldronHoverTask cauldronHoverTask;
     private BreweryTranslator translator;
     private boolean successfullLoad = false;
 
@@ -314,6 +316,11 @@ public class TheBrewingProject extends JavaPlugin implements TheBrewingProjectAp
         } else {
             pluginManager.registerEvents(new LegacyPlayerJoinListener(), this);
         }
+        
+        // Start cauldron hover task for action bar display
+        this.cauldronHoverTask = new CauldronHoverTask(this.breweryRegistry);
+        this.cauldronHoverTask.start();
+        
         Bukkit.getGlobalRegionScheduler().runAtFixedRate(this, this::updateStructures, 1, 1);
         Bukkit.getGlobalRegionScheduler().runAtFixedRate(this, this::otherTicking, 1, 1);
         RecipeReader<ItemStack> recipeReader = new RecipeReader<>(this.getDataFolder(), new BukkitRecipeResultReader(), BukkitIngredientManager.INSTANCE);
@@ -329,6 +336,10 @@ public class TheBrewingProject extends JavaPlugin implements TheBrewingProjectAp
 
     @Override
     public void onDisable() {
+        // Cancel cauldron hover task
+        if (cauldronHoverTask != null) {
+            cauldronHoverTask.cancel();
+        }
         closeDatabase();
     }
 

--- a/bukkit/src/main/java/dev/jsinco/brewery/bukkit/event/PlayerEventListener.java
+++ b/bukkit/src/main/java/dev/jsinco/brewery/bukkit/event/PlayerEventListener.java
@@ -225,11 +225,21 @@ public class PlayerEventListener implements Listener {
         cauldronOptional
                 .filter(cauldron -> itemStack.getType() == Material.CLOCK)
                 .filter(cauldron -> event.getPlayer().hasPermission("brewery.cauldron.time"))
-                .ifPresent(cauldron -> event.getPlayer().sendMessage(
-                        Component.translatable("tbp.cauldron.clock-message", Argument.tagResolver(
-                                Placeholder.parsed("time", TimeFormatter.format(cauldron.getTime(), TimeFormat.CLOCK_MECHANIC, TimeModifier.COOKING))
-                        ))
-                ));
+                .ifPresent(cauldron -> {
+                    Component timeMessage = Component.translatable("tbp.cauldron.clock-message", Argument.tagResolver(
+                            Placeholder.parsed("time", TimeFormatter.format(cauldron.getTime(), TimeFormat.CLOCK_MECHANIC, TimeModifier.COOKING))
+                    ));
+                    
+                    // Send to chat if enabled
+                    if (Config.config().cauldrons().clockTimeInChat()) {
+                        event.getPlayer().sendMessage(timeMessage);
+                    }
+                    
+                    // Send to action bar if click mode is enabled
+                    if (Config.config().cauldrons().clockTimeActionBar() == dev.jsinco.brewery.configuration.CauldronSection.ClockActionBarMode.CLICK) {
+                        event.getPlayer().sendActionBar(timeMessage);
+                    }
+                });
 
         cauldronOptional.ifPresent(ignored -> {
             event.setUseInteractedBlock(Event.Result.DENY);

--- a/bukkit/src/main/java/dev/jsinco/brewery/bukkit/event/PlayerEventListener.java
+++ b/bukkit/src/main/java/dev/jsinco/brewery/bukkit/event/PlayerEventListener.java
@@ -96,6 +96,11 @@ public class PlayerEventListener implements Listener {
     // Handle shift-click ingredient removal with higher priority
     @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true) //test and validate if that is correct
     public void onPlayerShiftClickCauldron(PlayerInteractEvent event) {
+        // Check if feature is enabled
+        if (!Config.config().cauldrons().enableIngredientRemoval()) {
+            return;
+        }
+        
         if (event.getAction() != Action.RIGHT_CLICK_BLOCK || !event.getPlayer().isSneaking() || event.getHand() != EquipmentSlot.HAND) {
             return;
         }

--- a/bukkit/src/main/java/dev/jsinco/brewery/bukkit/task/CauldronHoverTask.java
+++ b/bukkit/src/main/java/dev/jsinco/brewery/bukkit/task/CauldronHoverTask.java
@@ -1,0 +1,120 @@
+package dev.jsinco.brewery.bukkit.task;
+
+import dev.jsinco.brewery.api.vector.BreweryLocation;
+import dev.jsinco.brewery.bukkit.TheBrewingProject;
+import dev.jsinco.brewery.bukkit.api.BukkitAdapter;
+import dev.jsinco.brewery.bukkit.breweries.BreweryRegistry;
+import dev.jsinco.brewery.bukkit.breweries.BukkitCauldron;
+import dev.jsinco.brewery.configuration.CauldronSection;
+import dev.jsinco.brewery.configuration.Config;
+import dev.jsinco.brewery.format.TimeFormat;
+import dev.jsinco.brewery.format.TimeFormatter;
+import dev.jsinco.brewery.format.TimeModifier;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
+import net.kyori.adventure.text.minimessage.translation.Argument;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.scheduler.BukkitRunnable;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Task that displays cauldron brewing time in the action bar when a player
+ * is looking at a cauldron while holding a clock in their main or off-hand.
+ * Updates every second while looking at the cauldron to show current time.
+ */
+public class CauldronHoverTask extends BukkitRunnable {
+    
+    private final BreweryRegistry breweryRegistry;
+    private final Map<UUID, BreweryLocation> lastCauldronLookup = new HashMap<>();
+    
+    public CauldronHoverTask(BreweryRegistry breweryRegistry) {
+        this.breweryRegistry = breweryRegistry;
+    }
+    
+    @Override
+    public void run() {
+        // Only run if hover mode is enabled
+        if (Config.config().cauldrons().clockTimeActionBar() != CauldronSection.ClockActionBarMode.HOVER) {
+            return;
+        }
+        
+        for (Player player : Bukkit.getOnlinePlayers()) {
+            // Check if player has permission
+            if (!player.hasPermission("brewery.cauldron.time")) {
+                continue;
+            }
+            
+            // Check if player is holding a clock in main or off-hand
+            ItemStack mainHand = player.getInventory().getItemInMainHand();
+            ItemStack offHand = player.getInventory().getItemInOffHand();
+            
+            if (mainHand.getType() != Material.CLOCK && offHand.getType() != Material.CLOCK) {
+                // Clear last lookup and action bar if not holding clock anymore
+                if (lastCauldronLookup.remove(player.getUniqueId()) != null) {
+                    player.sendActionBar(Component.empty());
+                }
+                continue;
+            }
+            
+            // Get the block the player is looking at (max 5 blocks away)
+            Block targetBlock = player.getTargetBlockExact(5);
+            
+            if (targetBlock == null || !isCauldronBlock(targetBlock.getType())) {
+                // Clear last lookup and action bar if not looking at cauldron
+                if (lastCauldronLookup.remove(player.getUniqueId()) != null) {
+                    player.sendActionBar(Component.empty());
+                }
+                continue;
+            }
+            
+            // Check if this is an active brewing cauldron
+            BreweryLocation location = BukkitAdapter.toBreweryLocation(targetBlock);
+            BukkitCauldron cauldron = breweryRegistry.getActiveSinglePositionStructure(location)
+                    .filter(BukkitCauldron.class::isInstance)
+                    .map(BukkitCauldron.class::cast)
+                    .orElse(null);
+            
+            if (cauldron == null) {
+                // Clear last lookup and action bar if not a brewing cauldron
+                if (lastCauldronLookup.remove(player.getUniqueId()) != null) {
+                    player.sendActionBar(Component.empty());
+                }
+                continue;
+            }
+            
+            // Send updated action bar message every tick (will update every second)
+            Component timeMessage = Component.translatable("tbp.cauldron.clock-message", Argument.tagResolver(
+                    Placeholder.parsed("time", TimeFormatter.format(cauldron.getTime(), TimeFormat.CLOCK_MECHANIC, TimeModifier.COOKING))
+            ));
+            player.sendActionBar(timeMessage);
+            
+            // Remember this cauldron
+            lastCauldronLookup.put(player.getUniqueId(), location);
+        }
+    }
+    
+    /**
+     * Checks if the given material is a cauldron type
+     */
+    private boolean isCauldronBlock(Material material) {
+        return material == Material.CAULDRON || 
+               material == Material.WATER_CAULDRON || 
+               material == Material.LAVA_CAULDRON || 
+               material == Material.POWDER_SNOW_CAULDRON;
+    }
+    
+    /**
+     * Starts the hover detection task
+     */
+    public void start() {
+        // Run every 20 ticks (1 second) to update the action bar
+        this.runTaskTimer(TheBrewingProject.getInstance(), 0L, 20L);
+    }
+}

--- a/core/src/main/java/dev/jsinco/brewery/configuration/CauldronSection.java
+++ b/core/src/main/java/dev/jsinco/brewery/configuration/CauldronSection.java
@@ -31,4 +31,21 @@ public class CauldronSection extends OkaeriConfig {
     @CustomKey("cooking-minute-ticks")
     private long cookingMinuteTicks = Moment.MINUTE;
 
+    @Comment("Should the time message be displayed in chat when clicking a cauldron with a clock?")
+    @CustomKey("clock-time-in-chat")
+    private boolean clockTimeInChat = true;
+
+    @Comment({"How should the time be displayed in the action bar?",
+            "Options: 'hover' - show when looking at cauldron with clock in hand",
+            "         'click' - show only when clicking with clock",
+            "         'disabled' - don't show in action bar at all"})
+    @CustomKey("clock-time-action-bar")
+    private ClockActionBarMode clockTimeActionBar = ClockActionBarMode.DISABLED;
+
+    public enum ClockActionBarMode {
+        HOVER,
+        CLICK,
+        DISABLED
+    }
+
 }

--- a/core/src/main/java/dev/jsinco/brewery/configuration/CauldronSection.java
+++ b/core/src/main/java/dev/jsinco/brewery/configuration/CauldronSection.java
@@ -31,6 +31,14 @@ public class CauldronSection extends OkaeriConfig {
     @CustomKey("cooking-minute-ticks")
     private long cookingMinuteTicks = Moment.MINUTE;
 
+    @Comment("How many ingredients can be removed from a cauldron with shift right-click")
+    @CustomKey("max-removable-ingredients")
+    private int maxRemovableIngredients = 3;
+
+    @Comment("How long (in ticks) after adding an ingredient can it be removed with shift right-click")
+    @CustomKey("ingredient-removal-time-window")
+    private long ingredientRemovalTimeWindow = Moment.MINUTE;
+
     @Comment("Should the time message be displayed in chat when clicking a cauldron with a clock?")
     @CustomKey("clock-time-in-chat")
     private boolean clockTimeInChat = true;

--- a/core/src/main/java/dev/jsinco/brewery/configuration/CauldronSection.java
+++ b/core/src/main/java/dev/jsinco/brewery/configuration/CauldronSection.java
@@ -31,6 +31,10 @@ public class CauldronSection extends OkaeriConfig {
     @CustomKey("cooking-minute-ticks")
     private long cookingMinuteTicks = Moment.MINUTE;
 
+    @Comment("Enable ingredient removal feature - allows players to remove recently added ingredients with shift right-click")
+    @CustomKey("enable-ingredient-removal")
+    private boolean enableIngredientRemoval = true;
+
     @Comment("How many ingredients can be removed from a cauldron with shift right-click")
     @CustomKey("max-removable-ingredients")
     private int maxRemovableIngredients = 3;


### PR DESCRIPTION
- Brew Time can optionally be shown on Action Bar (default disabled)
- Brew Time can optionally be shown in Chat (default enabled)
- Brew time can update on Look at the cauldron when using a clock in main or offhand (default disabled)

- Implemented Removal of Latest added Items
- Configurable Amount (0 to disable)
- Configurable Limit Time (0 to disable)
- When removed all Ingredients Cauldron Brewing is resetted
- Message in Action bar when removing, item drops at Player pos and a small sound effect appears

> Need to Test Recipe accuracy if the Recipe is truly without the Ingredient when removed
> Need to proper Test with Permission and Claim Plugins! 
> tested on paper 1.21.10 without any other plugins