### PR TITLE
Fix: Sanitize ingredients for replicate command - Avoid ingredient groups

### DIFF
--- a/bukkit/src/main/java/dev/jsinco/brewery/bukkit/command/ReplicateCommand.java
+++ b/bukkit/src/main/java/dev/jsinco/brewery/bukkit/command/ReplicateCommand.java
@@ -12,6 +12,7 @@ import dev.jsinco.brewery.bukkit.command.argument.EnumArgument;
 import dev.jsinco.brewery.bukkit.command.argument.RecipeArgument;
 import dev.jsinco.brewery.bukkit.recipe.BukkitRecipeResult;
 import dev.jsinco.brewery.recipes.BrewScoreImpl;
+import dev.jsinco.brewery.util.IngredientUtil;
 import dev.jsinco.brewery.util.MessageUtil;
 import io.papermc.paper.command.brigadier.CommandSourceStack;
 import io.papermc.paper.command.brigadier.Commands;
@@ -42,7 +43,7 @@ public class ReplicateCommand {
     }
 
     private static void givePlayerBrew(Recipe<ItemStack> recipe, CommandContext<CommandSourceStack> context, Player target, BrewQuality quality) {
-        Brew brew = new BrewImpl(recipe.getSteps());
+        Brew brew = new BrewImpl(IngredientUtil.sanitizeSteps(recipe.getSteps()));
         BrewScore score = brew.score(recipe);
         if (score instanceof BrewScoreImpl scoreImpl) scoreImpl.setQualityOverride(quality);
         ItemStack brewItem = recipe.getRecipeResult(quality).newBrewItem(score, brew, new Brew.State.Other());

--- a/core/src/main/java/dev/jsinco/brewery/util/IngredientUtil.java
+++ b/core/src/main/java/dev/jsinco/brewery/util/IngredientUtil.java
@@ -1,0 +1,49 @@
+package dev.jsinco.brewery.util;
+
+import dev.jsinco.brewery.api.brew.BrewingStep;
+import dev.jsinco.brewery.api.ingredient.Ingredient;
+import dev.jsinco.brewery.api.ingredient.IngredientGroup;
+import dev.jsinco.brewery.api.ingredient.ScoredIngredient;
+
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class IngredientUtil {
+
+    private IngredientUtil() {
+        throw new UnsupportedOperationException("Utility class");
+    }
+
+    public static Map<Ingredient, Integer> sanitizeIngredients(Map<? extends Ingredient, Integer> ingredients) {
+        Map<Ingredient, Integer> output = new HashMap<>();
+        for (Map.Entry<? extends Ingredient, Integer> entry : ingredients.entrySet()) {
+            Ingredient ingredient = entry.getKey();
+            if (ingredient instanceof IngredientGroup ingredientGroup) {
+                ingredient = ingredientGroup.alternatives().stream().max(Comparator.comparing(groupIngredient ->
+                        groupIngredient instanceof ScoredIngredient scoredIngredient ? scoredIngredient.score() : 1D
+                )).orElse(null);
+            }
+            if (ingredient == null) {
+                continue;
+            }
+            output.put(ingredient, entry.getValue());
+        }
+        return output;
+    }
+
+    public static List<BrewingStep> sanitizeSteps(List<BrewingStep> steps) {
+        return steps.stream()
+                .map(IngredientUtil::sanitizeStep)
+                .toList();
+    }
+
+    public static BrewingStep sanitizeStep(BrewingStep step) {
+        return switch (step) {
+            case BrewingStep.Mix mix -> mix.withIngredients(sanitizeIngredients(mix.ingredients()));
+            case BrewingStep.Cook cook -> cook.withIngredients(sanitizeIngredients(cook.ingredients()));
+            default -> step;
+        };
+    }
+}


### PR DESCRIPTION
If the recipe has ingredient groups as an ingredient, then the recipe will be counted as ruined whenever score processing is done.