### PR TITLE
Fix: Avoid using strings as keys in ingredients

### DIFF
--- a/api/src/main/java/dev/jsinco/brewery/api/ingredient/Ingredient.java
+++ b/api/src/main/java/dev/jsinco/brewery/api/ingredient/Ingredient.java
@@ -1,5 +1,6 @@
 package dev.jsinco.brewery.api.ingredient;
 
+import dev.jsinco.brewery.api.util.BreweryKey;
 import net.kyori.adventure.text.Component;
 import org.jetbrains.annotations.ApiStatus;
 import org.jspecify.annotations.NonNull;
@@ -16,7 +17,15 @@ public interface Ingredient {
     /**
      * @return Key of the ingredient
      */
-    @NonNull String getKey();
+    @Deprecated(forRemoval = true)
+    default @NonNull String getKey() {
+        return key().toString();
+    }
+
+    /**
+     * @return Key of the ingredient
+     */
+    @NonNull BreweryKey key();
 
     /**
      * @return A component with a display name

--- a/api/src/main/java/dev/jsinco/brewery/api/ingredient/IngredientGroup.java
+++ b/api/src/main/java/dev/jsinco/brewery/api/ingredient/IngredientGroup.java
@@ -1,19 +1,15 @@
 package dev.jsinco.brewery.api.ingredient;
 
+import dev.jsinco.brewery.api.util.BreweryKey;
 import net.kyori.adventure.text.Component;
-import org.jspecify.annotations.NonNull;
 
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
-public record IngredientGroup(String key, Component displayName,
+public record IngredientGroup(BreweryKey key, Component displayName,
                               List<Ingredient> alternatives) implements Ingredient {
-    @Override
-    public @NonNull String getKey() {
-        return key;
-    }
 
     @Override
     public Optional<? extends Ingredient> findMatch(Set<BaseIngredient> baseIngredientSet) {

--- a/api/src/main/java/dev/jsinco/brewery/api/ingredient/IngredientManager.java
+++ b/api/src/main/java/dev/jsinco/brewery/api/ingredient/IngredientManager.java
@@ -66,7 +66,7 @@ public interface IngredientManager<I> {
         }
         String meta = matcher.group(1);
         String id = matcher.replaceAll("");
-        if(meta.isBlank()) {
+        if (meta.isBlank()) {
             return getIngredient(id);
         }
         ImmutableMap.Builder<IngredientMeta<?>, Object> metaBuilder = new ImmutableMap.Builder<>();
@@ -78,7 +78,7 @@ public interface IngredientManager<I> {
                 );
     }
 
-    private void addMeta(String metaElement, ImmutableMap.Builder<IngredientMeta<?>, Object> metaBuilder){
+    private void addMeta(String metaElement, ImmutableMap.Builder<IngredientMeta<?>, Object> metaBuilder) {
         String[] split = metaElement.split("=", 2);
         Preconditions.checkArgument(split.length == 2, "Invalid ingredient meta pattern, missing '=' sign: " + metaElement);
         String key = split[0].strip();
@@ -100,10 +100,10 @@ public interface IngredientManager<I> {
      */
     default String serializeIngredient(Ingredient ingredient) throws IllegalArgumentException {
         if (!(ingredient instanceof IngredientWithMeta metaIngredient)) {
-            return ingredient.getKey();
+            return ingredient.key().toString();
         }
         Map<IngredientMeta<?>, Object> meta = metaIngredient.meta();
-        return String.format("%s{%s}", metaIngredient.getKey(),
+        return String.format("%s{%s}", metaIngredient.key(),
                 meta.entrySet()
                         .stream()
                         .map(entry -> entry.getKey().key().minimalized() + "=" + entry.getKey().serializer().serialize(entry.getValue()))

--- a/api/src/main/java/dev/jsinco/brewery/api/ingredient/IngredientWithMeta.java
+++ b/api/src/main/java/dev/jsinco/brewery/api/ingredient/IngredientWithMeta.java
@@ -1,6 +1,7 @@
 package dev.jsinco.brewery.api.ingredient;
 
 import com.google.common.base.Preconditions;
+import dev.jsinco.brewery.api.util.BreweryKey;
 import net.kyori.adventure.text.Component;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
@@ -19,8 +20,8 @@ public record IngredientWithMeta(Ingredient ingredient,
     }
 
     @Override
-    public @NonNull String getKey() {
-        return ingredient.getKey();
+    public @NonNull BreweryKey key() {
+        return ingredient.key();
     }
 
     @Override
@@ -45,6 +46,7 @@ public record IngredientWithMeta(Ingredient ingredient,
 
     /**
      * Wrap this ingredient with an ingredient with meta instance
+     *
      * @param ingredient Ingredient to wrap
      * @return Ingredient with meta wrapping the ingredient
      */
@@ -54,8 +56,8 @@ public record IngredientWithMeta(Ingredient ingredient,
 
     /**
      * @param metaKey ingredientMetaKey
+     * @param <T>     Ingredient meta value
      * @return Ingredient meta value, or null if not present
-     * @param <T> Ingredient meta value
      */
     public <T> @Nullable T get(IngredientMeta<T> metaKey) {
         return (T) meta.get(metaKey);

--- a/api/src/main/java/dev/jsinco/brewery/api/ingredient/ScoredIngredient.java
+++ b/api/src/main/java/dev/jsinco/brewery/api/ingredient/ScoredIngredient.java
@@ -1,5 +1,6 @@
 package dev.jsinco.brewery.api.ingredient;
 
+import dev.jsinco.brewery.api.util.BreweryKey;
 import net.kyori.adventure.text.Component;
 import org.jspecify.annotations.NonNull;
 
@@ -15,8 +16,8 @@ import java.util.Set;
 public record ScoredIngredient(Ingredient baseIngredient, double score) implements Ingredient {
 
     @Override
-    public @NonNull String getKey() {
-        return baseIngredient.getKey();
+    public @NonNull BreweryKey key() {
+        return baseIngredient.key();
     }
 
     @Override

--- a/bukkit/src/main/java/dev/jsinco/brewery/bukkit/api/ingredient/PluginIngredient.java
+++ b/bukkit/src/main/java/dev/jsinco/brewery/bukkit/api/ingredient/PluginIngredient.java
@@ -19,8 +19,8 @@ public class PluginIngredient implements BaseIngredient {
     }
 
     @Override
-    public @NonNull String getKey() {
-        return key.toString();
+    public @NonNull BreweryKey key() {
+        return key;
     }
 
     @Override

--- a/bukkit/src/main/java/dev/jsinco/brewery/bukkit/command/argument/IngredientsArgument.java
+++ b/bukkit/src/main/java/dev/jsinco/brewery/bukkit/command/argument/IngredientsArgument.java
@@ -13,6 +13,7 @@ import dev.jsinco.brewery.bukkit.ingredient.BukkitIngredientManager;
 import dev.jsinco.brewery.bukkit.util.BukkitMessageUtil;
 import io.papermc.paper.command.brigadier.MessageComponentSerializer;
 import io.papermc.paper.command.brigadier.argument.CustomArgumentType;
+import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
 import org.jspecify.annotations.NonNull;
 
@@ -116,8 +117,8 @@ public class IngredientsArgument implements CustomArgumentType.Converted<Map<Ing
             splitIngredients.removeLast();
         }
         TheBrewingProject.getInstance().getRecipeRegistry().registeredIngredients().stream()
-                .map(Ingredient::getKey)
-                .map(ingredientKey -> ingredientKey.replaceAll("^minecraft:", ""))
+                .map(Ingredient::key)
+                .map(ingredientKey -> ingredientKey.minimalized(Key.MINECRAFT_NAMESPACE))
                 .filter(ingredientKey -> ingredientKey.startsWith(last))
                 .map(string -> "\"" + (splitIngredients.isEmpty() ? "" : String.join(",", splitIngredients) + ",") + string)
                 .forEach(builder::suggest);

--- a/bukkit/src/main/java/dev/jsinco/brewery/bukkit/ingredient/BreweryIngredient.java
+++ b/bukkit/src/main/java/dev/jsinco/brewery/bukkit/ingredient/BreweryIngredient.java
@@ -17,19 +17,14 @@ import org.jspecify.annotations.NonNull;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
-public record BreweryIngredient(BreweryKey ingredientKey) implements BaseIngredient {
-
-    @Override
-    public @NonNull String getKey() {
-        return ingredientKey.toString();
-    }
+public record BreweryIngredient(BreweryKey key) implements BaseIngredient {
 
     @Override
     public @NonNull Component displayName() {
-        return TheBrewingProject.getInstance().getRecipeRegistry().getRecipe(ingredientKey.minimalized())
+        return TheBrewingProject.getInstance().getRecipeRegistry().getRecipe(key.minimalized())
                 .map(recipe -> recipe.getRecipeResult(BrewQuality.EXCELLENT))
                 .map(RecipeResult::displayName)
-                .orElseGet(() -> Component.text(ingredientKey.minimalized()));
+                .orElseGet(() -> Component.text(key.minimalized()));
     }
 
     public static Optional<Ingredient> from(ItemStack itemStack) {

--- a/bukkit/src/main/java/dev/jsinco/brewery/bukkit/ingredient/BukkitIngredientManager.java
+++ b/bukkit/src/main/java/dev/jsinco/brewery/bukkit/ingredient/BukkitIngredientManager.java
@@ -83,7 +83,7 @@ public class BukkitIngredientManager implements IngredientManager<ItemStack> {
                                 return itemStack;
                             });
             case PluginIngredient pluginIngredient ->
-                    pluginIngredient.itemIntegration().createItem(pluginIngredient.getKey());
+                    pluginIngredient.itemIntegration().createItem(pluginIngredient.key().key());
             default -> Optional.empty();
         };
         if (ingredient instanceof IngredientWithMeta ingredientWithMeta) {

--- a/bukkit/src/main/java/dev/jsinco/brewery/bukkit/ingredient/SimpleIngredient.java
+++ b/bukkit/src/main/java/dev/jsinco/brewery/bukkit/ingredient/SimpleIngredient.java
@@ -2,6 +2,8 @@ package dev.jsinco.brewery.bukkit.ingredient;
 
 import dev.jsinco.brewery.api.ingredient.BaseIngredient;
 import dev.jsinco.brewery.api.ingredient.Ingredient;
+import dev.jsinco.brewery.api.util.BreweryKey;
+import dev.jsinco.brewery.bukkit.api.BukkitAdapter;
 import net.kyori.adventure.text.Component;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
@@ -18,8 +20,8 @@ import java.util.Optional;
 public record SimpleIngredient(Material material) implements BaseIngredient {
 
     @Override
-    public @NonNull String getKey() {
-        return material.getKey().toString();
+    public @NonNull BreweryKey key() {
+        return BukkitAdapter.toBreweryKey(material.getKey());
     }
 
     @Override

--- a/bukkit/src/main/java/dev/jsinco/brewery/bukkit/ingredient/UncheckedIngredientImpl.java
+++ b/bukkit/src/main/java/dev/jsinco/brewery/bukkit/ingredient/UncheckedIngredientImpl.java
@@ -6,7 +6,6 @@ import dev.jsinco.brewery.api.ingredient.UncheckedIngredient;
 import dev.jsinco.brewery.api.ingredient.WildcardIngredient;
 import dev.jsinco.brewery.api.util.BreweryKey;
 import dev.jsinco.brewery.api.util.Logger;
-import net.kyori.adventure.key.Key;
 
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -22,7 +21,7 @@ public final class UncheckedIngredientImpl implements UncheckedIngredient {
 
     public UncheckedIngredientImpl(Ingredient ingredient) {
         this.value = CompletableFuture.completedFuture(Optional.of(ingredient));
-        this.key = BreweryKey.parse(ingredient.getKey(), Key.MINECRAFT_NAMESPACE);
+        this.key = ingredient.key();
     }
 
     public Optional<Ingredient> retrieve() {

--- a/bukkit/src/main/java/dev/jsinco/brewery/bukkit/listener/PlayerEventListener.java
+++ b/bukkit/src/main/java/dev/jsinco/brewery/bukkit/listener/PlayerEventListener.java
@@ -361,7 +361,7 @@ public class PlayerEventListener implements Listener {
         Ingredient ingredient = BukkitIngredientManager.INSTANCE.getIngredient(event.getItem());
         for (ConsumableSerializer.Consumable consumable : DrunkenModifierSection.modifiers().consumables()) {
             String key = consumable.type().contains(":") ? consumable.type() : "minecraft:" + consumable.type();
-            if (ingredient.getKey().equalsIgnoreCase(key)) {
+            if (ingredient.key().toString().equalsIgnoreCase(key)) {
                 List<ModifierConsume> consumedModifiers = consumable.modifiers().entrySet().stream()
                         .map(entry -> new ModifierConsume(DrunkenModifierSection.modifiers().modifier(entry.getKey()), entry.getValue(), true))
                         .toList();

--- a/bukkit/src/main/java/dev/jsinco/brewery/bukkit/util/BukkitIngredientUtil.java
+++ b/bukkit/src/main/java/dev/jsinco/brewery/bukkit/util/BukkitIngredientUtil.java
@@ -1,16 +1,18 @@
 package dev.jsinco.brewery.bukkit.util;
 
 import dev.jsinco.brewery.api.ingredient.Ingredient;
-import dev.jsinco.brewery.api.ingredient.WildcardIngredient;
-import dev.jsinco.brewery.api.util.BreweryKey;
-import dev.jsinco.brewery.api.util.Pair;
-import dev.jsinco.brewery.bukkit.ingredient.UncheckedIngredientImpl;
-import dev.jsinco.brewery.bukkit.ingredient.BukkitIngredientManager;
-import dev.jsinco.brewery.configuration.Config;
 import dev.jsinco.brewery.api.ingredient.UncheckedIngredient;
+import dev.jsinco.brewery.api.util.Pair;
+import dev.jsinco.brewery.bukkit.ingredient.BukkitIngredientManager;
+import dev.jsinco.brewery.bukkit.ingredient.UncheckedIngredientImpl;
+import dev.jsinco.brewery.configuration.Config;
 import dev.jsinco.brewery.util.ItemColorUtil;
 import net.kyori.adventure.key.Key;
-import org.bukkit.*;
+import org.bukkit.Bukkit;
+import org.bukkit.Keyed;
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.Tag;
 import org.bukkit.inventory.ItemStack;
 import org.jspecify.annotations.Nullable;
 
@@ -33,7 +35,7 @@ public class BukkitIngredientUtil {
                 topIngredient = ingredient.getKey();
                 topIngredientAmount = ingredient.getValue();
             }
-            String key = ingredient.getKey().getKey();
+            String key = ingredient.getKey().key().toString();
             Color color = ItemColorUtil.getItemColor(key);
             if (color == null) {
                 continue;

--- a/core/src/main/java/dev/jsinco/brewery/configuration/IngredientsSection.java
+++ b/core/src/main/java/dev/jsinco/brewery/configuration/IngredientsSection.java
@@ -151,7 +151,7 @@ public class IngredientsSection extends OkaeriConfig {
                             return Optional.empty();
                         }
                         return Optional.of(new IngredientGroup(
-                                "#brewery:" + key,
+                                new BreweryKey("#brewery", key),
                                 displayName,
                                 ingredients.stream()
                                         .flatMap(Optional::stream)


### PR DESCRIPTION
This caused code fragility. Should be better now