### PR TITLE
feat: Allow blacklisting any integration

### DIFF
--- a/bukkit-api/src/main/java/dev/jsinco/brewery/bukkit/api/integration/IntegrationTypes.java
+++ b/bukkit-api/src/main/java/dev/jsinco/brewery/bukkit/api/integration/IntegrationTypes.java
@@ -4,9 +4,9 @@ import dev.jsinco.brewery.api.integration.IntegrationType;
 
 public class IntegrationTypes {
 
-    public static IntegrationType<ItemIntegration> ITEM = new IntegrationType<>(ItemIntegration.class, "item integration");
-    public static IntegrationType<StructureIntegration> STRUCTURE = new IntegrationType<>(StructureIntegration.class, "structure integration");
-    public static IntegrationType<PlaceholderIntegration> PLACEHOLDER = new IntegrationType<>(PlaceholderIntegration.class, "placeholder integration");
-    public static IntegrationType<ChestShopIntegration> CHEST_SHOP = new IntegrationType<>(ChestShopIntegration.class, "chest shop integration");
-    public static IntegrationType<EventIntegration<?>> EVENT = new IntegrationType<>(EventIntegration.class, "event integration");
+    public static IntegrationType<ItemIntegration> ITEM = new IntegrationType<>(ItemIntegration.class, "item");
+    public static IntegrationType<StructureIntegration> STRUCTURE = new IntegrationType<>(StructureIntegration.class, "structure");
+    public static IntegrationType<PlaceholderIntegration> PLACEHOLDER = new IntegrationType<>(PlaceholderIntegration.class, "placeholder");
+    public static IntegrationType<ChestShopIntegration> CHEST_SHOP = new IntegrationType<>(ChestShopIntegration.class, "chest_shop");
+    public static IntegrationType<EventIntegration<?>> EVENT = new IntegrationType<>(EventIntegration.class, "event");
 }

--- a/bukkit-impl/src/main/java/dev/jsinco/brewery/bukkit/TheBrewingProject.java
+++ b/bukkit-impl/src/main/java/dev/jsinco/brewery/bukkit/TheBrewingProject.java
@@ -161,8 +161,6 @@ public class TheBrewingProject extends JavaPlugin implements TheBrewingProjectAp
     }
 
     public void initialize() {
-        EventSection.migrateEvents(getDataFolder());
-        Config.load(this.getDataFolder(), serializers());
         this.translator = new BreweryTranslator(new File(this.getDataFolder(), "locale"));
         DrunkenModifierSection.load(this.getDataFolder(), serializers());
         translator.reload();
@@ -182,6 +180,8 @@ public class TheBrewingProject extends JavaPlugin implements TheBrewingProjectAp
         saveResources();
         Migrations.migrateAllConfigFiles(this.getDataFolder());
         this.resourcePackColors = new ResourcePackColors();
+        EventSection.migrateEvents(getDataFolder());
+        Config.load(this.getDataFolder(), serializers());
         integrationManager.registerIntegrations(resourcePackColors);
         CompletableFuture.allOf(integrationManager.retrieve(IntegrationTypes.ITEM)
                 .stream()

--- a/bukkit-impl/src/main/java/dev/jsinco/brewery/bukkit/integration/IntegrationManagerImpl.java
+++ b/bukkit-impl/src/main/java/dev/jsinco/brewery/bukkit/integration/IntegrationManagerImpl.java
@@ -24,7 +24,10 @@ import dev.jsinco.brewery.bukkit.integration.structure.LandsIntegration;
 import dev.jsinco.brewery.bukkit.integration.structure.TownyIntegration;
 import dev.jsinco.brewery.bukkit.integration.structure.WorldGuardIntegration;
 import dev.jsinco.brewery.bukkit.util.color.ResourcePackColors;
+import dev.jsinco.brewery.configuration.Config;
 
+import java.util.Locale;
+import java.util.Objects;
 import java.util.Set;
 
 public class IntegrationManagerImpl implements IntegrationManager {
@@ -63,11 +66,16 @@ public class IntegrationManagerImpl implements IntegrationManager {
 
     @Override
     public <T extends Integration> void register(IntegrationType<? extends T> type, T integration) {
-        if (!integration.isEnabled()) {
+        String fullId = (type.name() + "." + integration.getId()).toLowerCase(Locale.ROOT);
+        if (!integration.isEnabled() || Config.config().integrationBlacklist()
+                .stream()
+                .filter(Objects::nonNull)
+                .map(string -> string.toLowerCase(Locale.ROOT))
+                .anyMatch(fullId::contains)) {
             return;
         }
 
-        Logger.log("Registering integration " + integration.getId() + " with type " + type.name());
+        Logger.log("Registering integration " + integration.getId() + " with type " + type.name() + " integration");
         integrationRegistry.register(type, integration);
     }
 

--- a/core/src/main/java/dev/jsinco/brewery/configuration/Config.java
+++ b/core/src/main/java/dev/jsinco/brewery/configuration/Config.java
@@ -110,6 +110,12 @@ public class Config extends OkaeriConfig implements Configuration {
     @Comment("The aliases for the 'tbp' command")
     private List<String> commandAliases = List.of("brewery", "brew");
 
+    @CustomKey("integration-blacklist")
+    @Comment({"Disable some integrations. (Only loaded on startup)",
+            "Matches against an integration type and integration name.",
+            "for example 'item.nexo' for exact match, and just 'nexo' to match with all nexo integrations"})
+    private List<String> integrationBlacklist = List.of();
+
     @Exclude
     private static Config instance;
 
@@ -223,5 +229,9 @@ public class Config extends OkaeriConfig implements Configuration {
 
     public List<String> commandAliases() {
         return this.commandAliases;
+    }
+
+    public List<String> integrationBlacklist() {
+        return this.integrationBlacklist;
     }
 }


### PR DESCRIPTION
For example `item.nexo` would match against the item integration for nexo, just `nexo` would match against any nexo integration, and just `item` would match against any item integration