### PR TITLE
fix: Only use completed recipe colors for cauldorn

### DIFF
--- a/bukkit-impl/src/main/java/dev/jsinco/brewery/bukkit/breweries/BukkitCauldron.java
+++ b/bukkit-impl/src/main/java/dev/jsinco/brewery/bukkit/breweries/BukkitCauldron.java
@@ -189,7 +189,7 @@ public class BukkitCauldron implements Cauldron {
             return convert(Config.config().cauldrons().failedParticleColor());
         }
         RecipeResult<ItemStack> recipeResult = matcherResult.recipeResult().orElse(null);
-        if (recipeResult != null) {
+        if (matcherResult.score().completed() && recipeResult != null) {
             return Color.fromRGB(recipeResult.brewColor().getRGB() & 0xFFFFFF);
         }
         Optional<Color> defaultRecipeColor = BrewAdapterAccess.getDefaultRecipe(


### PR DESCRIPTION
Previously the colors of the nearest completed recipe was used when deciding the cauldron colors. This makes sure that the nearest recipe is also completed, or otherwise uses the same colors as would be provided by the default brews mechanism.