### PR TITLE
Apply stumble and drunken walk events to vehicles and elytra

### DIFF
--- a/bukkit-impl/src/main/java/dev/jsinco/brewery/bukkit/effect/DrunkenImpulse.java
+++ b/bukkit-impl/src/main/java/dev/jsinco/brewery/bukkit/effect/DrunkenImpulse.java
@@ -1,0 +1,126 @@
+package dev.jsinco.brewery.bukkit.effect;
+
+import dev.jsinco.brewery.bukkit.util.VectorUtil;
+import dev.jsinco.brewery.configuration.EventSection;
+import org.bukkit.Material;
+import org.bukkit.entity.*;
+import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.util.Vector;
+
+import java.util.EnumSet;
+import java.util.Random;
+
+public record DrunkenImpulse(
+        Vector pushDirection,
+        double magnitude,
+        double yawRate,
+        double pitchRate
+) {
+    private static final EnumSet<Material> HARNESSES = EnumSet.of(
+            Material.WHITE_HARNESS,
+            Material.LIGHT_GRAY_HARNESS,
+            Material.GRAY_HARNESS,
+            Material.BLACK_HARNESS,
+            Material.BROWN_HARNESS,
+            Material.RED_HARNESS,
+            Material.ORANGE_HARNESS,
+            Material.YELLOW_HARNESS,
+            Material.LIME_HARNESS,
+            Material.GREEN_HARNESS,
+            Material.CYAN_HARNESS,
+            Material.LIGHT_BLUE_HARNESS,
+            Material.BLUE_HARNESS,
+            Material.PURPLE_HARNESS,
+            Material.MAGENTA_HARNESS,
+            Material.PINK_HARNESS
+    );
+
+    public static DrunkenImpulse generate(Random random,
+                                          double minMagnitude, double maxMagnitude,
+                                          double minTurnRate, double maxTurnRate
+    ) {
+        boolean invertYaw = random.nextBoolean();
+        boolean invertPitch = random.nextBoolean();
+        return new DrunkenImpulse(
+                VectorUtil.randomUnitVector(random),
+                random.nextDouble(minMagnitude, maxMagnitude),
+                (invertYaw ? -1.0 : 1.0) * random.nextDouble(minTurnRate, maxTurnRate),
+                (invertPitch ? -1.0 : 1.0) * random.nextDouble(minTurnRate, maxTurnRate)
+        );
+    }
+
+    public static DrunkenImpulse lerp(DrunkenImpulse from, DrunkenImpulse to, double t) {
+        return new DrunkenImpulse(
+                VectorUtil.lerp(from.pushDirection, to.pushDirection, t),
+                org.joml.Math.lerp(from.magnitude, to.magnitude, t),
+                org.joml.Math.lerp(from.yawRate, to.yawRate, t),
+                org.joml.Math.lerp(from.pitchRate, to.pitchRate, t)
+        );
+    }
+
+    public void applyTo(Player player, boolean applyToElytra) {
+        if (!player.isOnline() || player.isDead() || player.hasNoPhysics()) {
+            return;
+        }
+        Entity vehicle = player.getVehicle();
+        if (vehicle != null) {
+            if (EventSection.events().stumbleInVehicles()) {
+                applyToVehicle(vehicle);
+            }
+        } else if (player.isGliding()) {
+            if (EventSection.events().stumbleWithElytra() && applyToElytra) {
+                turnRandomlyOmnidirectional(player);
+            }
+        } else if (player.isOnGround()) {
+            moveRandomlyHorizontal(player, 1.0);
+        }
+    }
+    private void applyToVehicle(Entity vehicle) {
+        if (vehicle.isDead() || !vehicle.isTicking() || vehicle.isInsideVehicle() || vehicle.hasNoPhysics()) {
+            return;
+        }
+        switch (vehicle) {
+            // Boat movement code is horrendously jank and controlled almost entirely client-side, and thanks to
+            // MC-104494 it is impossible to move or rotate a boat without stopping it in place.
+            case Minecart minecart ->
+                    moveRandomlyHorizontal(minecart, 2.0);
+            case Llama llama when llama.isTamed() && llama.isOnGround() ->
+                    moveRandomlyHorizontal(llama, 2.0);
+            case Camel camel when isSaddled(camel) && !camel.isSitting() && camel.isOnGround() ->
+                    moveRandomlyHorizontal(camel, 2.0);
+            case AbstractHorse horseLike when isSaddled(horseLike) && horseLike.isOnGround() ->
+                    moveRandomlyHorizontal(horseLike, 2.0);
+            case AbstractNautilus nautilus when isSaddled(nautilus) ->
+                    moveRandomlyOmnidirectional(nautilus, 2.5);
+            case Pig pig when isSaddled(pig) && pig.isOnGround() ->
+                    moveRandomlyHorizontal(pig, 2.0);
+            case Strider strider when isSaddled(strider) && !strider.isShivering() ->
+                    moveRandomlyHorizontal(strider, 1.0);
+            case HappyGhast happyGhast when isHarnessed(happyGhast) ->
+                    moveRandomlyOmnidirectional(happyGhast, 2.0);
+            default -> {}
+        }
+    }
+    private boolean isSaddled(Mob entity) {
+        return entity.getEquipment().getItem(EquipmentSlot.SADDLE).getType() == Material.SADDLE;
+    }
+    private boolean isHarnessed(HappyGhast entity) {
+        return HARNESSES.contains(entity.getEquipment().getItem(EquipmentSlot.BODY).getType());
+    }
+
+    private void moveRandomlyHorizontal(Entity entity, double scale) {
+        entity.setVelocity(VectorUtil.horizontalScaledBy(pushDirection, magnitude * scale));
+    }
+
+    private void moveRandomlyOmnidirectional(Entity entity, double scale) {
+        entity.setVelocity(VectorUtil.omnidirectionalScaledBy(pushDirection, magnitude * scale));
+    }
+
+    private void turnRandomlyOmnidirectional(Entity entity) {
+        entity.setRotation(
+                entity.getYaw() + (float) Math.toDegrees(yawRate),
+                Math.clamp(entity.getPitch() + (float) Math.toDegrees(pitchRate), -90.0f, 90.0f)
+        );
+    }
+
+}

--- a/bukkit-impl/src/main/java/dev/jsinco/brewery/bukkit/effect/DrunkenImpulse.java
+++ b/bukkit-impl/src/main/java/dev/jsinco/brewery/bukkit/effect/DrunkenImpulse.java
@@ -2,12 +2,15 @@ package dev.jsinco.brewery.bukkit.effect;
 
 import dev.jsinco.brewery.bukkit.util.VectorUtil;
 import dev.jsinco.brewery.configuration.EventSection;
-import org.bukkit.Material;
+import io.papermc.paper.datacomponent.DataComponentTypes;
+import io.papermc.paper.datacomponent.item.Equippable;
+import io.papermc.paper.registry.RegistryKey;
+import io.papermc.paper.registry.TypedKey;
+import io.papermc.paper.registry.set.RegistryKeySet;
 import org.bukkit.entity.*;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.util.Vector;
 
-import java.util.EnumSet;
 import java.util.Random;
 
 public record DrunkenImpulse(
@@ -16,25 +19,6 @@ public record DrunkenImpulse(
         double yawRate,
         double pitchRate
 ) {
-    private static final EnumSet<Material> HARNESSES = EnumSet.of(
-            Material.WHITE_HARNESS,
-            Material.LIGHT_GRAY_HARNESS,
-            Material.GRAY_HARNESS,
-            Material.BLACK_HARNESS,
-            Material.BROWN_HARNESS,
-            Material.RED_HARNESS,
-            Material.ORANGE_HARNESS,
-            Material.YELLOW_HARNESS,
-            Material.LIME_HARNESS,
-            Material.GREEN_HARNESS,
-            Material.CYAN_HARNESS,
-            Material.LIGHT_BLUE_HARNESS,
-            Material.BLUE_HARNESS,
-            Material.PURPLE_HARNESS,
-            Material.MAGENTA_HARNESS,
-            Material.PINK_HARNESS
-    );
-
     public static DrunkenImpulse generate(Random random,
                                           double minMagnitude, double maxMagnitude,
                                           double minTurnRate, double maxTurnRate
@@ -101,11 +85,19 @@ public record DrunkenImpulse(
             default -> {}
         }
     }
-    private boolean isSaddled(Mob entity) {
-        return entity.getEquipment().getItem(EquipmentSlot.SADDLE).getType() == Material.SADDLE;
+    private static boolean isSaddled(Mob entity) {
+        return hasEquippable(entity, EquipmentSlot.SADDLE);
     }
-    private boolean isHarnessed(HappyGhast entity) {
-        return HARNESSES.contains(entity.getEquipment().getItem(EquipmentSlot.BODY).getType());
+    private static boolean isHarnessed(HappyGhast entity) {
+        return hasEquippable(entity, EquipmentSlot.BODY);
+    }
+    private static boolean hasEquippable(Mob entity, EquipmentSlot slot) {
+        Equippable equippable = entity.getEquipment().getItem(slot).getData(DataComponentTypes.EQUIPPABLE);
+        if (equippable != null && equippable.slot() == slot) {
+            RegistryKeySet<EntityType> allowed = equippable.allowedEntities();
+            return allowed == null || allowed.contains(TypedKey.create(RegistryKey.ENTITY_TYPE, entity.getType().key()));
+        }
+        return false;
     }
 
     private void moveRandomlyHorizontal(Entity entity, double scale) {

--- a/bukkit-impl/src/main/java/dev/jsinco/brewery/bukkit/effect/named/DrunkenWalkNamedExecutable.java
+++ b/bukkit-impl/src/main/java/dev/jsinco/brewery/bukkit/effect/named/DrunkenWalkNamedExecutable.java
@@ -6,6 +6,7 @@ import dev.jsinco.brewery.api.event.NamedDrunkEvent;
 import dev.jsinco.brewery.api.util.Pair;
 import dev.jsinco.brewery.bukkit.Statistics;
 import dev.jsinco.brewery.bukkit.TheBrewingProject;
+import dev.jsinco.brewery.bukkit.effect.DrunkenImpulse;
 import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
@@ -14,10 +15,7 @@ import org.bukkit.util.Vector;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Random;
-import java.util.UUID;
+import java.util.*;
 
 public class DrunkenWalkNamedExecutable implements EventPropertyExecutable {
 
@@ -50,47 +48,50 @@ public class DrunkenWalkNamedExecutable implements EventPropertyExecutable {
 
     static class DrunkenWalkHandler {
 
-        private final LinkedList<Pair<Vector, Integer>> vectors;
+        private final Queue<Pair<DrunkenImpulse, Integer>> impulses;
         private int currentTimestamp;
         private int duration;
         private int timestamp = 0;
         private final Player player;
-        private Vector currentPush;
+        private DrunkenImpulse currentImpulse;
         private final Location startingPoint;
 
-        private static int DIRECTION_INTERVAL = 20;
-        private static double MINIMUM_PUSH_MAGNITUDE = 0.1;
-        private static double MAXIMUM_PUSH_MAGNITUDE = 0.4;
+        private static final int DIRECTION_INTERVAL = 20;
+        private static final double MINIMUM_PUSH_MAGNITUDE = 0.1;
+        private static final double MAXIMUM_PUSH_MAGNITUDE = 0.4;
+        private static final double MINIMUM_TURN_RATE = Math.PI / 40.0;
+        private static final double MAXIMUM_TURN_RATE = Math.PI / 10.0;
         private static final Random RANDOM = new Random();
 
         DrunkenWalkHandler(int duration, Player player) {
             this.duration = duration;
             this.player = player;
-            this.vectors = compileRandomVectors(duration);
-            pollNewCurrentVector(vectors);
+            this.impulses = compileRandomImpulses(duration);
+            pollNewCurrentImpulse(impulses);
             this.startingPoint = player.getLocation().clone();
         }
 
-        private void pollNewCurrentVector(LinkedList<Pair<Vector, Integer>> vectors) {
-            Pair<Vector, Integer> pair = vectors.poll();
-            this.currentPush = pair == null ? null : pair.first();
+        private void pollNewCurrentImpulse(Queue<Pair<DrunkenImpulse, Integer>> vectors) {
+            Pair<DrunkenImpulse, Integer> pair = vectors.poll();
+            this.currentImpulse = pair == null ? null : pair.first();
             this.currentTimestamp = pair == null ? 0 : pair.second();
         }
 
-        private LinkedList<Pair<Vector, Integer>> compileRandomVectors(int duration) {
+        private Queue<Pair<DrunkenImpulse, Integer>> compileRandomImpulses(int duration) {
             int amount = duration / DIRECTION_INTERVAL;
-            LinkedList<Pair<Vector, Integer>> output = new LinkedList<>();
+            Queue<Pair<DrunkenImpulse, Integer>> output = new LinkedList<>();
             for (int i = 0; i < amount; i++) {
-                double angle = RANDOM.nextDouble(Math.PI * 2);
-                double radius = RANDOM.nextDouble(MINIMUM_PUSH_MAGNITUDE, MAXIMUM_PUSH_MAGNITUDE);
-                Vector vector = new Vector(Math.cos(angle), 0, Math.sin(angle)).multiply(radius);
-                output.add(new Pair<>(vector, i * DIRECTION_INTERVAL));
+                DrunkenImpulse impulse = DrunkenImpulse.generate(RANDOM,
+                        MINIMUM_PUSH_MAGNITUDE, MAXIMUM_PUSH_MAGNITUDE,
+                        MINIMUM_TURN_RATE, MAXIMUM_TURN_RATE
+                );
+                output.add(new Pair<>(impulse, i * DIRECTION_INTERVAL));
             }
             return output;
         }
 
         public void tick(ScheduledTask task) {
-            if (duration <= timestamp++ || currentPush == null) {
+            if (duration <= timestamp++ || currentImpulse == null) {
                 task.cancel();
                 if (player.isOnline() && player.getWorld() == startingPoint.getWorld()) {
                     Statistics.registerDrunkenTraversedBlocks(player.getLocation().distance(startingPoint));
@@ -98,26 +99,26 @@ public class DrunkenWalkNamedExecutable implements EventPropertyExecutable {
                 return;
             }
             Vector walk = TheBrewingProject.getInstance().getPlayerWalkListener().getRegisteredMovement(player.getUniqueId());
-            if (!player.isOnline() || !player.isOnGround() || walk == null || walk.lengthSquared() == 0D
+            if (!player.isOnline() || walk == null || walk.lengthSquared() == 0D
                     || TheBrewingProject.getInstance().getActiveEventsRegistry().hasActiveEvent(player.getUniqueId(), NamedDrunkEvent.fromKey("stumble"))
             ) {
                 return;
             }
-            Pair<Vector, Integer> next = vectors.peek();
+            Pair<DrunkenImpulse, Integer> next = impulses.peek();
             if (next == null) {
-                player.setVelocity(currentPush);
+                currentImpulse.applyTo(player, false);
                 return;
             }
-            Vector nextPush = next.first();
+            DrunkenImpulse nextImpulse = next.first();
             int nextTimestamp = next.second();
             if (nextTimestamp <= timestamp) {
-                pollNewCurrentVector(vectors);
-                player.setVelocity(currentPush);
+                pollNewCurrentImpulse(impulses);
+                currentImpulse.applyTo(player, false);
                 return;
             }
             double interpolation = (double) (nextTimestamp - timestamp) / (nextTimestamp - currentTimestamp);
-            Vector newPush = currentPush.clone().multiply(interpolation).add(nextPush.clone().multiply(1D - interpolation));
-            player.setVelocity(newPush);
+            DrunkenImpulse newImpulse = DrunkenImpulse.lerp(nextImpulse, currentImpulse, interpolation);
+            newImpulse.applyTo(player, false);
         }
     }
 

--- a/bukkit-impl/src/main/java/dev/jsinco/brewery/bukkit/effect/named/StumbleNamedExecutable.java
+++ b/bukkit-impl/src/main/java/dev/jsinco/brewery/bukkit/effect/named/StumbleNamedExecutable.java
@@ -4,9 +4,10 @@ import dev.jsinco.brewery.api.event.EventPropertyExecutable;
 import dev.jsinco.brewery.api.event.EventStepProperty;
 import dev.jsinco.brewery.api.event.NamedDrunkEvent;
 import dev.jsinco.brewery.bukkit.TheBrewingProject;
+import dev.jsinco.brewery.bukkit.effect.DrunkenImpulse;
 import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
 import org.bukkit.Bukkit;
-import org.bukkit.entity.Player;
+import org.bukkit.entity.*;
 import org.bukkit.util.Vector;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
@@ -18,6 +19,8 @@ import java.util.UUID;
 public class StumbleNamedExecutable implements EventPropertyExecutable {
 
     private static final int STUMBLE_DURATION = 10;
+    private static final double MAX_MAGNITUDE = 0.1;
+    private static final double MAX_TURN_RATE = Math.PI / 20.0;
 
     @Override
     public @NonNull ExecutionResult execute(UUID contextPlayer, List<EventStepProperty> eventStepProperties) {
@@ -39,46 +42,46 @@ public class StumbleNamedExecutable implements EventPropertyExecutable {
     }
 
     static class StumbleHandler {
-        private final Vector pushDirection2;
+
+        private final DrunkenImpulse impulse1;
+        private final DrunkenImpulse impulse2;
+
         private int countDown;
         private final int duration;
         private final Player player;
-        private final Vector pushDirection1;
         private static final Random RANDOM = new Random();
 
         public StumbleHandler(int duration, Player player) {
             this.countDown = duration;
             this.duration = duration;
             this.player = player;
-            double radians1 = RANDOM.nextDouble(Math.PI * 2);
             Vector walk = TheBrewingProject.getInstance().getPlayerWalkListener().getRegisteredMovement(player.getUniqueId());
             double maxMagnitude;
             if (walk == null) {
-                maxMagnitude = 0.1;
+                maxMagnitude = MAX_MAGNITUDE;
             } else {
-                maxMagnitude = Math.max(0.1, walk.length());
+                maxMagnitude = Math.max(MAX_MAGNITUDE, walk.length());
             }
-            this.pushDirection1 = new Vector(Math.cos(radians1), 0, Math.sin(radians1))
-                    .multiply(RANDOM.nextDouble(maxMagnitude));
-            double radians2 = RANDOM.nextDouble(Math.PI * 2);
-            this.pushDirection2 = new Vector(Math.cos(radians2), 0, Math.sin(radians2))
-                    .multiply(RANDOM.nextDouble(maxMagnitude));
+            this.impulse1 = DrunkenImpulse.generate(RANDOM,
+                    0.0, maxMagnitude,
+                    0.0, MAX_TURN_RATE
+            );
+            this.impulse2 = DrunkenImpulse.generate(RANDOM,
+                    0.0, maxMagnitude,
+                    0.0, MAX_TURN_RATE
+            );
         }
 
         public void tick(ScheduledTask task) {
-            if (!player.isOnline() || countDown-- < 0) {
+            if (!player.isOnline() || player.isDead() || countDown-- < 0) {
                 task.cancel();
                 return;
             }
-            if (!player.isOnGround()) {
-                return;
-            }
             double progress = ((double) duration - (double) countDown) / duration;
-            Vector pushDirection = pushDirection2.clone()
-                    .multiply(progress)
-                    .add(pushDirection1.clone().multiply(1 - progress));
-            player.setVelocity(pushDirection);
+            DrunkenImpulse impulse = DrunkenImpulse.lerp(impulse1, impulse2, progress);
+            impulse.applyTo(player, true);
         }
+
     }
 
     @Override

--- a/bukkit-impl/src/main/java/dev/jsinco/brewery/bukkit/util/VectorUtil.java
+++ b/bukkit-impl/src/main/java/dev/jsinco/brewery/bukkit/util/VectorUtil.java
@@ -16,7 +16,7 @@ public class VectorUtil {
 
     public static Vector randomUnitVector(Random random) {
         double yaw = random.nextDouble(Math.PI * 2);
-        double pitch = random.nextDouble(-Math.PI / 2, Math.PI * 2);
+        double pitch = random.nextDouble(-Math.PI / 2, Math.PI / 2);
         return toUnitVector(yaw, pitch);
     }
     /**

--- a/bukkit-impl/src/main/java/dev/jsinco/brewery/bukkit/util/VectorUtil.java
+++ b/bukkit-impl/src/main/java/dev/jsinco/brewery/bukkit/util/VectorUtil.java
@@ -1,11 +1,34 @@
 package dev.jsinco.brewery.bukkit.util;
 
 import dev.jsinco.brewery.api.vector.BreweryVector;
+import org.bukkit.util.Vector;
 import org.joml.Matrix3d;
 import org.joml.Vector3d;
 import org.joml.Vector3i;
 
+import java.util.Random;
+
 public class VectorUtil {
+
+    public static Vector lerp(Vector from, Vector to, double t) {
+        return from.clone().multiply(1.0 - t).add(to.clone().multiply(t));
+    }
+
+    public static Vector randomUnitVector(Random random) {
+        double yaw = random.nextDouble(Math.PI * 2);
+        double pitch = random.nextDouble(-Math.PI / 2, Math.PI * 2);
+        return new Vector(
+                Math.cos(yaw) * Math.cos(pitch),
+                Math.sin(yaw) * Math.cos(pitch),
+                Math.sin(pitch)
+        );
+    }
+    public static Vector horizontalScaledBy(Vector unit, double magnitude) {
+        return unit.clone().setY(0).normalize().multiply(magnitude);
+    }
+    public static Vector omnidirectionalScaledBy(Vector unit, double magnitude) {
+        return unit.clone().multiply(magnitude);
+    }
 
     /**
      * Will not mutate the initial vector
@@ -30,4 +53,5 @@ public class VectorUtil {
     public static BreweryVector toBreweryVector(Vector3i vector) {
         return new BreweryVector(vector.x(), vector.y(), vector.z());
     }
+
 }

--- a/bukkit-impl/src/main/java/dev/jsinco/brewery/bukkit/util/VectorUtil.java
+++ b/bukkit-impl/src/main/java/dev/jsinco/brewery/bukkit/util/VectorUtil.java
@@ -17,10 +17,18 @@ public class VectorUtil {
     public static Vector randomUnitVector(Random random) {
         double yaw = random.nextDouble(Math.PI * 2);
         double pitch = random.nextDouble(-Math.PI / 2, Math.PI * 2);
+        return toUnitVector(yaw, pitch);
+    }
+    /**
+     * @param yaw Minecraft yaw, clockwise angle from +Z
+     * @param pitch Minecraft pitch, upwards angle from horizon
+     * @return Equivalent unit vector
+     */
+    public static Vector toUnitVector(double yaw, double pitch) {
         return new Vector(
-                Math.cos(yaw) * Math.cos(pitch),
-                Math.sin(yaw) * Math.cos(pitch),
-                Math.sin(pitch)
+                -Math.sin(yaw) * Math.cos(pitch),
+                Math.sin(pitch),
+                Math.cos(yaw) * Math.cos(pitch)
         );
     }
     public static Vector horizontalScaledBy(Vector unit, double magnitude) {

--- a/core/src/main/java/dev/jsinco/brewery/configuration/EventSection.java
+++ b/core/src/main/java/dev/jsinco/brewery/configuration/EventSection.java
@@ -105,6 +105,14 @@ public class EventSection extends OkaeriConfig {
     @CustomKey("blurred-speech")
     private boolean blurredSpeech = true;
 
+    @Comment({"Drunken players randomly move ridden minecarts and saddled/harnessed animals", "Boats are not supported due to MC-104494"})
+    @CustomKey("stumble-in-vehicles")
+    private boolean stumbleInVehicles = true;
+
+    @Comment({"Drunken players randomly change direction when flying with an elytra"})
+    @CustomKey("stumble-with-elytra")
+    private boolean stumbleWithElytra = true;
+
     @Comment("What upwards velocity the player will get in the kaboom event")
     @CustomKey("kaboom-velocity")
     private double kaboomVelocity = 0.2;
@@ -266,6 +274,14 @@ public class EventSection extends OkaeriConfig {
 
     public boolean blurredSpeech() {
         return this.blurredSpeech;
+    }
+
+    public boolean stumbleInVehicles() {
+        return this.stumbleInVehicles;
+    }
+
+    public boolean stumbleWithElytra() {
+        return this.stumbleWithElytra;
     }
 
     public double kaboomVelocity() {


### PR DESCRIPTION
- If the player is riding a vehicle, the stumble and drunken walk events will randomly move the vehicle similarly to how it affects players on the ground.
- If the player is gliding with an elytra, the stumble event randomly rotates the player's facing direction for a short time (drunken walk not included, that would be evil).